### PR TITLE
Darts - bugfix: negative numbers were possible

### DIFF
--- a/book_programs/chapter_2/darts.py
+++ b/book_programs/chapter_2/darts.py
@@ -32,7 +32,7 @@ except ValueError:
     print("ERROR: Could not convert n to an integer")
 
 # Argument is negtive
-if 'dart_throws' in globals() and dart_throws < 0:
+if 'dart_throws_count' in globals() and dart_throws_count < 0:
     bad_input = True
     print("ERROR: n cannot be negative")
 


### PR DESCRIPTION
I just noticed that my code still allowed negative numbers to be entered due to a missing rename.
